### PR TITLE
升级JNI接口，优化内存

### DIFF
--- a/include/commons/commons.h
+++ b/include/commons/commons.h
@@ -168,21 +168,21 @@ namespace mdl {
 #define EXCEPTION_FOOTER } catch (const MDLException &exception) {                                                   \
                             const char *message = exception.what();                                                  \
                             LOGE(message);                                                                           \
-                            jclass exception_class = env->FindClass("com/baidu/mdl/demo/MDLException"); \
+                            jclass exception_class = env->FindClass("com/baidu/graph/sdk/autoscanner/MDLException"); \
                             if (exception_class != NULL) {                                                           \
                                 env->ThrowNew(exception_class, message);                                             \
                             }                                                                                        \
                          } catch (const std::exception &exception) {                                                 \
                             const char *message = (mdl::exception_prefix + exception.what()).c_str();                \
                             LOGE(message);                                                                           \
-                            jclass exception_class = env->FindClass("com/baidu/mdl/demo/MDLException"); \
+                            jclass exception_class = env->FindClass("com/baidu/graph/sdk/autoscanner/MDLException"); \
                             if (exception_class != NULL) {                                                           \
                                 env->ThrowNew(exception_class, message);                                             \
                             }                                                                                        \
                          } catch (...) {                                                                             \
                             const char *message = (mdl::exception_prefix + "Unknown Exception.").c_str();            \
                             LOGE(message);                                                                           \
-                            jclass exception_class = env->FindClass("com/baidu/mdl/demo/MDLException"); \
+                            jclass exception_class = env->FindClass("com/baidu/graph/sdk/autoscanner/MDLException"); \
                             if (exception_class != NULL) {                                                           \
                                 env->ThrowNew(exception_class, message);                                             \
                             }                                                                                        \

--- a/include/mdl_jni.h
+++ b/include/mdl_jni.h
@@ -32,30 +32,45 @@ extern "C" {
 /**
  * load model & params of the net for android
  */
-JNIEXPORT jboolean JNICALL Java_com_baidu_mdl_demo_MDL_load(
+JNIEXPORT jboolean JNICALL Java_com_baidu_graph_sdk_autoscanner_MDL_load(
         JNIEnv *env, jclass thiz, jstring modelPath, jstring weightsPath);
 
 /**
- * object detection for anroid
+ * take preprocessed float array as input
  */
 JNIEXPORT jfloatArray JNICALL Java_com_baidu_mdl_demo_MDL_predictImage(
         JNIEnv *env, jclass thiz, jfloatArray buf);
 
+ /**
+     * take the original yuv data as input
+     * @param env
+     * @param thiz
+     * @param yuv the original yuv data
+     * @param imgWidth width of original image
+     * @param imgHeight height of original image
+     * @param targetWidth  width of the network input
+     * @param targetHeight height of the network input
+     * @param meanValues  meanvlue array of the params
+     * @return cordinates of rect
+     */
+JNIEXPORT jfloatArray JNICALL Java_com_baidu_graph_sdk_autoscanner_MDL_predictYuv(
+        JNIEnv *env, jclass thiz, jbyteArray yuv, int imgWidth, int imgHeight, int targetWidth, int targetHeight, jfloatArray meanValues);
+
 /**
  * set thread num
  */
-JNIEXPORT void JNICALL Java_com_baidu_mdl_demo_MDL_setThreadNum(
+JNIEXPORT void JNICALL Java_com_baidu_graph_sdk_autoscanner_MDL_setThreadNum(
         JNIEnv *env, jclass thiz, jint num);
 
 /**
  * clear data of the net when destroy for android
  */
-JNIEXPORT void JNICALL Java_com_baidu_mdl_demo_MDL_clear(
+JNIEXPORT void JNICALL Java_com_baidu_graph_sdk_autoscanner_MDL_clear(
         JNIEnv *env, jclass thiz);
 /**
  * validate wheather the device is fast enough for obj detection for android
  */
-JNIEXPORT jboolean JNICALL Java_com_baidu_mdl_demo_MDL_validate(
+JNIEXPORT jboolean JNICALL Java_com_baidu_graph_sdk_autoscanner_MDL_validate(
         JNIEnv *env, jclass thiz);
 
 #ifdef __cplusplus

--- a/src/loader/loader.cpp
+++ b/src/loader/loader.cpp
@@ -25,6 +25,7 @@ SOFTWARE.
 #include <zconf.h>
 #include <errno.h>
 #include <sys/mman.h>
+#include <math/gemm.h>
 
 #include "base/matrix.h"
 
@@ -355,6 +356,13 @@ namespace mdl {
             delete matrix;
         }
         _matrices.clear();
+        for (vector<Gemmer*>::iterator it = Gemmer::gemmers.begin(); it != Gemmer::gemmers.end(); it ++) {
+            if (NULL != *it){
+                delete *it;
+                *it = nullptr;
+            }
+        }
+        Gemmer::gemmers.clear();
         _cleared = true;
     }
 };

--- a/src/mdl_jni.cpp
+++ b/src/mdl_jni.cpp
@@ -49,7 +49,54 @@ namespace mdl {
         return cppstr;
     }
 
-    JNIEXPORT jboolean JNICALL Java_com_baidu_mdl_demo_MDL_load(JNIEnv *env, jclass thiz, jstring modelPath, jstring weightsPath) {
+     static inline int yuv_to_rgb(int y, int u, int v, float *r, float *g, float *b)
+    {
+        int r1 = (int)(y + 1.370705 * (v - 128));
+        int g1 = (int)(y - 0.698001 * (u - 128) - 0.703125 * (v - 128));
+        int b1 = (int)(y + 1.732446 * (u - 128));
+
+        r1 = (int) fminf(255, fmaxf(0, r1));
+        g1 = (int) fminf(255, fmaxf(0, g1));
+        b1 = (int) fminf(255, fmaxf(0, b1));
+        *r = r1;
+        *g = g1;
+        *b = b1;
+
+        return 0;
+    }
+
+   void convert_nv21_to_matrix(uint8_t *nv21,float *matrix, int width, int height, int targetWidth, int targetHeight, float *meanvalues) {
+        const uint8_t *yData = nv21;
+        const uint8_t *vuData = nv21 + width * height;
+
+        const int yRowStride = width;
+        const int vuRowStride = width;
+
+        float scale_x = width * 1.0f / targetWidth;
+        float scale_y = height * 1.0f /targetHeight;
+
+        for (int j = 0; j < targetHeight; ++j) {
+            int y = j * scale_y;
+            const uint8_t *pY = yData + y * yRowStride;
+            const uint8_t *pVU = vuData + (y >> 1) * vuRowStride;
+            for (int i = 0; i < targetWidth; ++i) {
+                int x = i * scale_x;
+                const int offset = ((x >> 1) << 1);
+                float r = 0;
+                float g = 0;
+                float b = 0;
+                yuv_to_rgb(pY[x], pVU[offset + 1], pVU[offset], &r, &g, &b);
+                int r_index = j * targetWidth + i;
+                int g_index = r_index + targetWidth * targetHeight;
+                int b_index = g_index + targetWidth * targetHeight;
+                matrix[r_index] = r - meanvalues[0];
+                matrix[g_index] = g - meanvalues[1];
+                matrix[b_index] = b - meanvalues[2];
+            }
+        }
+    }
+
+    JNIEXPORT jboolean JNICALL Java_com_baidu_graph_sdk_autoscanner_MDL_load(JNIEnv *env, jclass thiz, jstring modelPath, jstring weightsPath) {
         std::lock_guard<std::mutex> lock(shared_mutex);
         LOGI("jni load invoked");
         bool success = false;
@@ -66,7 +113,7 @@ namespace mdl {
         return success ? JNI_TRUE : JNI_FALSE;
     }
 
-    JNIEXPORT void JNICALL Java_com_baidu_mdl_demo_MDL_setThreadNum(
+    JNIEXPORT void JNICALL Java_com_baidu_graph_sdk_autoscanner_MDL_setThreadNum(
         JNIEnv *env, jclass thiz, jint num) {
          EXCEPTION_HEADER
           Loader *loader = Loader::shared_instance();
@@ -85,9 +132,9 @@ namespace mdl {
         }
 
 
-    JNIEXPORT jfloatArray JNICALL Java_com_baidu_mdl_demo_MDL_predictImage(JNIEnv *env, jclass thiz, jfloatArray buf) {
+    JNIEXPORT jfloatArray JNICALL Java_com_baidu_graph_sdk_autoscanner_MDL_predictImage(JNIEnv *env, jclass thiz, jfloatArray buf) {
         std::lock_guard<std::mutex> lock(shared_mutex);
-        LOGI("jni predict invoked");
+        LOGI("jni predictImage invoked");
         vector<float> cpp_result;
         jfloatArray result = NULL;
         int count = 0;
@@ -103,7 +150,8 @@ namespace mdl {
                 dataPointer = env->GetFloatArrayElements(buf, NULL);
             }
             cpp_result = net->predict(dataPointer);
-    
+            env->ReleaseFloatArrayElements(buf, dataPointer, 0 );
+
             count = cpp_result.size();
             result = env->NewFloatArray(count);
             env->SetFloatArrayRegion(result, 0, count, &cpp_result[0]);
@@ -112,7 +160,55 @@ namespace mdl {
         return result;
     }
 
-    JNIEXPORT void JNICALL Java_com_baidu_mdl_demo_MDL_clear(JNIEnv *env, jclass thiz) {
+    JNIEXPORT jfloatArray JNICALL Java_com_baidu_graph_sdk_autoscanner_MDL_predictYuv(JNIEnv *env, jclass thiz, jbyteArray yuv,
+     int imgWidth, int imgHeight, int targetWidth, int targetHeight, jfloatArray meanValues) {
+        std::lock_guard<std::mutex> lock(shared_mutex);
+
+        LOGI("jni predictYuv invoked");
+        vector<float> cpp_result;
+        jfloatArray result = NULL;
+        int count = 0;
+        EXCEPTION_HEADER
+            Loader *loader = Loader::shared_instance();
+            if (!loader->get_loaded()) {
+                throw_exception("loader is not loaded yet");
+            }
+            if(yuv == nullptr) {
+              throw_exception("yuv byteArray should not be null");
+            }
+            if(meanValues == nullptr) {
+              throw_exception("meanValues array should not be null");
+            }
+            int yuvLength = env->GetArrayLength(yuv);
+            if(yuvLength != imgWidth * imgHeight * 3 / 2) {
+               throw_exception("yuv dataLength not equal to imgWidth * imgHeight * 3 / 2");
+            }
+            int meanvaluesLength = env->GetArrayLength(meanValues);
+
+            if(meanvaluesLength != 3) {
+               throw_exception("meanValues array length should be 3");
+            }
+            Net *net = get_net_instance(loader->_model);
+
+            uint8_t *dataPointer = (uint8_t *)env->GetByteArrayElements(yuv, NULL);
+
+            float *meanValuesPointer = env->GetFloatArrayElements(meanValues, NULL);
+
+            float matrix[targetWidth * targetHeight * 3];
+
+            convert_nv21_to_matrix(dataPointer, matrix, imgWidth, imgHeight, targetWidth, targetHeight, meanValuesPointer);
+
+            cpp_result = net->predict(matrix);
+            env->ReleaseByteArrayElements(yuv, (jbyte *)dataPointer, 0 );
+            count = cpp_result.size();
+            result = env->NewFloatArray(count);
+            env->SetFloatArrayRegion(result, 0, count, &cpp_result[0]);
+        EXCEPTION_FOOTER
+
+        return result;
+    }
+
+    JNIEXPORT void JNICALL Java_com_baidu_graph_sdk_autoscanner_MDL_clear(JNIEnv *env, jclass thiz) {
         std::lock_guard<std::mutex> lock(shared_mutex);
         LOGI("jni clear invoked");
         EXCEPTION_HEADER
@@ -126,7 +222,7 @@ namespace mdl {
         LOGI("jni clear returned");
     }
 
-    JNIEXPORT jboolean JNICALL Java_com_baidu_mdl_demo_MDL_validate(JNIEnv *env, jclass thiz) {
+    JNIEXPORT jboolean JNICALL Java_com_baidu_graph_sdk_autoscanner_MDL_validate(JNIEnv *env, jclass thiz) {
         std::lock_guard<std::mutex> lock(shared_mutex);
         LOGI("jni validate invoked");
         bool success = false;


### PR DESCRIPTION
1、add predict interface for yuv input & modify packageName 
2、Cleaning up the memory occupied by the matrix operation