### PR TITLE
change clang to gcc in android cross-compilation

### DIFF
--- a/src/operators/resize_op.h
+++ b/src/operators/resize_op.h
@@ -33,7 +33,7 @@ class ResizeOp
           DeviceType, ResizeParam, operators::ResizeKernel<DeviceType, T>> {
  public:
   ResizeOp(const std::string &type, const VariableNameMap &inputs,
-           const VariableNameMap &outputs, const framework::AttributeMap attrs,
+           const VariableNameMap &outputs, const framework::AttributeMap &attrs,
            std::shared_ptr<framework::Scope> scope)
       : framework::OperatorWithKernel<DeviceType, ResizeParam,
                                       operators::ResizeKernel<DeviceType, T>>(

--- a/tools/android-cmake/android.toolchain.cmake
+++ b/tools/android-cmake/android.toolchain.cmake
@@ -159,7 +159,7 @@ endif()
 
 # Default values for configurable variables.
 if(NOT ANDROID_TOOLCHAIN)
-  set(ANDROID_TOOLCHAIN clang)
+  set(ANDROID_TOOLCHAIN gcc)
 endif()
 if(NOT ANDROID_ABI)
   set(ANDROID_ABI armeabi-v7a)


### PR DESCRIPTION
fix #653 